### PR TITLE
Decode unknown attributes

### DIFF
--- a/pkcs12.go
+++ b/pkcs12.go
@@ -204,7 +204,8 @@ func convertAttribute(attribute *pkcs12Attribute) (key, value string, err error)
 		key = "Microsoft CSP Name"
 		isString = true
 	default:
-		return "", "", errors.New("pkcs12: unknown attribute with OID " + attribute.Id.String())
+		return "Unknown_OID_" + attribute.Id.String(),
+			hex.EncodeToString(attribute.Value.Bytes), nil
 	}
 
 	if isString {


### PR DESCRIPTION
[RFC 7292](https://tools.ietf.org/html/rfc7292#section-4.2) says "Other attributes are allowed", so failing to decode to PEM is not the right thing to do.
This change returns unknown attributes as a raw hex byte string.