### PR TITLE
Java trust store compatibility

### DIFF
--- a/bmp-string.go
+++ b/bmp-string.go
@@ -30,6 +30,26 @@ func bmpString(s string) ([]byte, error) {
 	return append(ret, 0, 0), nil
 }
 
+func asn1BmpString(s string) ([]byte, error) {
+	// Slice is computed from the following elements:
+	// - one byte for the type
+	// - len octet(s)
+	// - string
+	ret := make([]byte, 0, 2*len(s)+2)
+
+	ret = append(ret, 30)
+	ret = append(ret, []byte{byte(uint(len(s)) * 2)}...)
+
+	for _, r := range s {
+		if t, _ := utf16.EncodeRune(r); t != 0xfffd {
+			return nil, errors.New("pkcs12: string contains characters that cannot be encoded in UCS-2")
+		}
+		ret = append(ret, byte(r/256), byte(r%256))
+	}
+
+	return ret, nil
+}
+
 func decodeBMPString(bmpString []byte) (string, error) {
 	if len(bmpString)%2 != 0 {
 		return "", errors.New("pkcs12: odd-length BMP string")

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -44,7 +44,8 @@ var (
 	oidLocalKeyID       = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 21})
 	oidMicrosoftCSPName = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 311, 17, 1})
 
-	oidJavaTrustStore = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 113894, 746875, 1, 1})
+	oidJavaTrustStore   = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 113894, 746875, 1, 1})
+	oidExtendedKeyUsage = asn1.ObjectIdentifier([]int{2, 5, 29, 37, 0})
 )
 
 type pfxPdu struct {
@@ -561,16 +562,27 @@ func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string
 	var pfx pfxPdu
 	pfx.Version = 3
 
+	var certAttributes []pkcs12Attribute
+
 	// Setting this attribute will make the certificates trusted in Java >= 1.8
-	var javaTrustStoreAttr pkcs12Attribute
-	javaTrustStoreAttr.Id = oidJavaTrustStore
-	javaTrustStoreAttr.Value.Class = 0
-	javaTrustStoreAttr.Value.Tag = 17
-	javaTrustStoreAttr.Value.IsCompound = true
+	extKeyUsageOidBytes, err := asn1.Marshal(oidExtendedKeyUsage)
+	if err != nil {
+		return nil, err
+	}
+
+	certAttributes = append(certAttributes, pkcs12Attribute{
+		Id: oidJavaTrustStore,
+		Value: asn1.RawValue{
+			Class:      0,
+			Tag:        17,
+			IsCompound: true,
+			Bytes:      extKeyUsageOidBytes,
+		},
+	})
 
 	var certBags []safeBag
 	for _, cert := range certs {
-		certBag, err := makeCertBag(cert.Raw, []pkcs12Attribute{javaTrustStoreAttr})
+		certBag, err := makeCertBag(cert.Raw, certAttributes)
 		if err != nil {
 			return nil, err
 		}
@@ -595,7 +607,7 @@ func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string
 	if _, err = rand.Read(pfx.MacData.MacSalt); err != nil {
 		return nil, err
 	}
-	pfx.MacData.Iterations = 1
+	pfx.MacData.Iterations = 2048
 	if err = computeMac(&pfx.MacData, authenticatedSafeBytes, encodedPassword); err != nil {
 		return nil, err
 	}

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -553,7 +553,7 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 //
 // EncodeTrustStore creates a single SafeContents that's encrypted with RC2
 // and contains the certificates.
-func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string) (pfxData []byte, err error) {
+func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string, friendlyName string) (pfxData []byte, err error) {
 	encodedPassword, err := bmpString(password)
 	if err != nil {
 		return nil, err
@@ -579,6 +579,23 @@ func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string
 			Bytes:      extKeyUsageOidBytes,
 		},
 	})
+
+	if friendlyName != "" {
+		encodedFriendlyName, err := asn1BmpString(friendlyName)
+		if err != nil {
+			return nil, err
+		}
+
+		certAttributes = append(certAttributes, pkcs12Attribute{
+			Id: oidFriendlyName,
+			Value: asn1.RawValue{
+				Class:      0,
+				Tag:        17,
+				IsCompound: true,
+				Bytes:      encodedFriendlyName,
+			},
+		})
+	}
 
 	var certBags []safeBag
 	for _, cert := range certs {


### PR DESCRIPTION
I've run into some issues where Java libraries don't seem to like PKCS12 files produced by this library, but are perfectly
happy with ones created by `keytool` from the same files.

The only differences I can see between the outputs are that keytool sets a value for the `javaTrustStore` attribute, and also includes the `friendlyName` attribute. It also uses more than 1 iteration on the MAC hash.

Note:
Much of this work was written by hetesiistvan on his fork of this repo, I've just adapted it slightly to solve only these issues.
https://github.com/hetesiistvan/go-pkcs12