### PR TITLE
Set friendlyName for certificates inside Trust Stores

### DIFF
--- a/bmp-string.go
+++ b/bmp-string.go
@@ -9,14 +9,27 @@ import (
 	"unicode/utf16"
 )
 
-// bmpString returns s encoded in UCS-2 with a zero terminator.
+// bmpStringZeroTerminated returns s encoded in UCS-2 with a zero terminator.
+func bmpStringZeroTerminated(s string) ([]byte, error) {
+	// References:
+	// https://tools.ietf.org/html/rfc7292#appendix-B.1
+	// The above RFC provides the info that BMPStrings are NULL terminated.
+
+	ret, err := bmpString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(ret, 0, 0), nil
+}
+
+// bmpString returns s encoded in UCS-2
 func bmpString(s string) ([]byte, error) {
 	// References:
 	// https://tools.ietf.org/html/rfc7292#appendix-B.1
 	// https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane
 	//  - non-BMP characters are encoded in UTF 16 by using a surrogate pair of 16-bit codes
 	//	  EncodeRune returns 0xfffd if the rune does not need special encoding
-	//  - the above RFC provides the info that BMPStrings are NULL terminated.
 
 	ret := make([]byte, 0, 2*len(s)+2)
 
@@ -27,7 +40,7 @@ func bmpString(s string) ([]byte, error) {
 		ret = append(ret, byte(r/256), byte(r%256))
 	}
 
-	return append(ret, 0, 0), nil
+	return ret, nil
 }
 
 func decodeBMPString(bmpString []byte) (string, error) {

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -26,7 +26,7 @@ func TestPbDecrypterFor(t *testing.T) {
 		},
 	}
 
-	pass, _ := bmpString("Sesame open")
+	pass, _ := bmpStringZeroTerminated("Sesame open")
 
 	_, _, err := pbDecrypterFor(alg, pass)
 	if _, ok := err.(NotImplementedError); !ok {
@@ -64,7 +64,7 @@ func TestPbEncrypterFor(t *testing.T) {
 		},
 	}
 
-	pass, _ := bmpString("Sesame open")
+	pass, _ := bmpStringZeroTerminated("Sesame open")
 
 	_, _, err := pbEncrypterFor(alg, pass)
 	if _, ok := err.(NotImplementedError); !ok {
@@ -125,7 +125,7 @@ func TestPbDecrypt(t *testing.T) {
 				}.RawASN1(),
 			},
 		}
-		password, _ := bmpString("sesame")
+		password, _ := bmpStringZeroTerminated("sesame")
 
 		plaintext, err := pbDecrypt(decryptable, password)
 		if err != test.expectedError {
@@ -159,7 +159,7 @@ func TestPbEncrypt(t *testing.T) {
 				}.RawASN1(),
 			},
 		}
-		p, _ := bmpString("sesame")
+		p, _ := bmpStringZeroTerminated("sesame")
 
 		err := pbEncrypt(&td, c, p)
 		if err != nil {

--- a/mac_test.go
+++ b/mac_test.go
@@ -21,7 +21,7 @@ func TestVerifyMac(t *testing.T) {
 	}
 
 	message := []byte{11, 12, 13, 14, 15}
-	password, _ := bmpString("")
+	password, _ := bmpStringZeroTerminated("")
 
 	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 3})
 	err := verifyMac(&td, message, password)
@@ -35,7 +35,7 @@ func TestVerifyMac(t *testing.T) {
 		t.Errorf("Expected incorrect password, got err: %v", err)
 	}
 
-	password, _ = bmpString("Sesame open")
+	password, _ = bmpStringZeroTerminated("Sesame open")
 	err = verifyMac(&td, message, password)
 	if err != nil {
 		t.Errorf("err: %v", err)
@@ -50,7 +50,7 @@ func TestComputeMac(t *testing.T) {
 	}
 
 	message := []byte{11, 12, 13, 14, 15}
-	password, _ := bmpString("Sesame open")
+	password, _ := bmpStringZeroTerminated("Sesame open")
 
 	td.Mac.Algorithm.Algorithm = asn1.ObjectIdentifier([]int{1, 2, 3})
 	err := computeMac(&td, message, password)

--- a/pbkdf_test.go
+++ b/pbkdf_test.go
@@ -13,7 +13,7 @@ func TestThatPBKDFWorksCorrectlyForLongKeys(t *testing.T) {
 	cipherInfo := shaWithTripleDESCBC{}
 
 	salt := []byte("\xff\xff\xff\xff\xff\xff\xff\xff")
-	password, _ := bmpString("sesame")
+	password, _ := bmpStringZeroTerminated("sesame")
 	key := cipherInfo.deriveKey(salt, password, 2048)
 
 	if expected := []byte("\x7c\xd9\xfd\x3e\x2b\x3b\xe7\x69\x1a\x44\xe3\xbe\xf0\xf9\xea\x0f\xb9\xb8\x97\xd4\xe3\x25\xd9\xd1"); bytes.Compare(key, expected) != 0 {

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -140,7 +140,7 @@ func unmarshal(in []byte, out interface{}) error {
 // labeled "PRIVATE KEY".  To decode a PKCS#12 file, use DecodeChain instead,
 // and use the encoding/pem package to convert to PEM if necessary.
 func ToPEM(pfxData []byte, password string) ([]*pem.Block, error) {
-	encodedPassword, err := bmpString(password)
+	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, ErrIncorrectPassword
 	}
@@ -263,7 +263,7 @@ func Decode(pfxData []byte, password string) (privateKey interface{}, certificat
 // be the leaf certificate, and subsequent certificates, if any, are assumed to
 // comprise the CA certificate chain.
 func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, err error) {
-	encodedPassword, err := bmpString(password)
+	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -320,7 +320,7 @@ func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certi
 // PKCS#12 file containing exclusively certificates with attribute 2.16.840.1.113894.746875.1.1,
 // which is used by Java to designate a trust anchor.
 func DecodeTrustStore(pfxData []byte, password string) (certs []*x509.Certificate, err error) {
-	encodedPassword, err := bmpString(password)
+	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func getSafeContents(p12Data, password []byte, expectedItems int) (bags []safeBa
 // LocalKeyId attribute set to the SHA-1 fingerprint of the end-entity
 // certificate.
 func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, password string) (pfxData []byte, err error) {
-	encodedPassword, err := bmpString(password)
+	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 // EncodeTrustStore creates a single SafeContents that's encrypted with RC2
 // and contains the certificates.
 func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string) (pfxData []byte, err error) {
-	encodedPassword, err := bmpString(password)
+	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Split off from #17 as discussed.

This takes the CommonName from each certificate passed to EncodeTrustStore and adds it as the `friendlyName` OID attribute for the cert.

Openssl and Keytool let you override the name for each certificate, but this would complicate the API somewhat, and I think it's rare that you wouldn't want the CN anyway.

The encoding of the value is slightly different to the way other strings are encoded, so `bmpString` has become un-terminated, and a `bmpStringZeroTerminated` counterpart has been added.