### PR TITLE
Support triple DES certificate encryption

### DIFF
--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -71,7 +71,7 @@ func TestTrustStore(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pfxData, err := EncodeTrustStore(rand.Reader, []*x509.Certificate{cert}, "password")
+		pfxData, err := EncodeTrustStore(rand.Reader, []*x509.Certificate{cert}, "password", false)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Add support to encrypt P12 certificates with triple DES. Pretty much equivalent to "-descert" flag of openssl.

I require this functionality because openssl 3 throws an error when trying to parse P12 that use RC2 algorithm when "-legacy" flag is not specified.