### PR TITLE
Support encoding with different parameters (including modern algorithms, password-less)

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -265,10 +265,10 @@ type encryptable interface {
 	SetData([]byte)
 }
 
-func makePBES2Parameters(rand io.Reader, iterations int) ([]byte, error) {
+func makePBES2Parameters(rand io.Reader, iterations int, saltLen int) ([]byte, error) {
 	var err error
 
-	randomSalt := make([]byte, 8)
+	randomSalt := make([]byte, saltLen)
 	if _, err := rand.Read(randomSalt); err != nil {
 		return nil, err
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -265,20 +265,16 @@ type encryptable interface {
 	SetData([]byte)
 }
 
-func makePBES2Parameters(rand io.Reader, iterations int, saltLen int) ([]byte, error) {
+func makePBES2Parameters(rand io.Reader, salt []byte, iterations int) ([]byte, error) {
 	var err error
 
-	randomSalt := make([]byte, saltLen)
-	if _, err := rand.Read(randomSalt); err != nil {
-		return nil, err
-	}
 	randomIV := make([]byte, 16)
 	if _, err := rand.Read(randomIV); err != nil {
 		return nil, err
 	}
 
 	var kdfparams pbkdf2Params
-	if kdfparams.Salt.FullBytes, err = asn1.Marshal(randomSalt); err != nil {
+	if kdfparams.Salt.FullBytes, err = asn1.Marshal(salt); err != nil {
 		return nil, err
 	}
 	kdfparams.Iterations = iterations

--- a/crypto.go
+++ b/crypto.go
@@ -200,7 +200,7 @@ func pbes2CipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher
 		return nil, nil, errors.New("pkcs12: only octet string salts are supported for pbkdf2")
 	}
 
-	// TODO: handle kdfParams.KeyLength (it's currently hard-coded to 32, which is the default for AES-256)
+	// TODO: handle kdfParams.KeyLength (it's currently hard-coded below to 32, which is the default for AES-256)
 
 	var prf func() hash.Hash
 	switch {

--- a/crypto.go
+++ b/crypto.go
@@ -200,6 +200,8 @@ func pbes2CipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher
 		return nil, nil, errors.New("pkcs12: only octet string salts are supported for pbkdf2")
 	}
 
+	// TODO: handle kdfParams.KeyLength (it's currently hard-coded to 32, which is the default for AES-256)
+
 	var prf func() hash.Hash
 	switch {
 	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA256):

--- a/crypto.go
+++ b/crypto.go
@@ -178,8 +178,8 @@ type pbes2Params struct {
 type pbkdf2Params struct {
 	Salt       asn1.RawValue
 	Iterations int
-	KeyLength  int `asn1:"optional"`
-	Prf        pkix.AlgorithmIdentifier
+	KeyLength  int                      `asn1:"optional"`
+	Prf        pkix.AlgorithmIdentifier `asn1:"optional"`
 }
 
 func pbes2CipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.Block, []byte, error) {

--- a/mac.go
+++ b/mac.go
@@ -31,7 +31,7 @@ var (
 	oidSHA256 = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1})
 )
 
-func verifyMac(macData *macData, message, password []byte) error {
+func doMac(macData *macData, message, password []byte) ([]byte, error) {
 	var hFn func() hash.Hash
 	var key []byte
 	switch {
@@ -42,13 +42,19 @@ func verifyMac(macData *macData, message, password []byte) error {
 		hFn = sha256.New
 		key = pbkdf(sha256Sum, 32, 64, macData.MacSalt, password, macData.Iterations, 3, 32)
 	default:
-		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+		return nil, NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
 	}
 
 	mac := hmac.New(hFn, key)
 	mac.Write(message)
-	expectedMAC := mac.Sum(nil)
+	return mac.Sum(nil), nil
+}
 
+func verifyMac(macData *macData, message, password []byte) error {
+	expectedMAC, err := doMac(macData, message, password)
+	if err != nil {
+		return err
+	}
 	if !hmac.Equal(macData.Mac.Digest, expectedMAC) {
 		return ErrIncorrectPassword
 	}
@@ -56,15 +62,10 @@ func verifyMac(macData *macData, message, password []byte) error {
 }
 
 func computeMac(macData *macData, message, password []byte) error {
-	if !macData.Mac.Algorithm.Algorithm.Equal(oidSHA1) {
-		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
+	digest, err := doMac(macData, message, password)
+	if err != nil {
+		return err
 	}
-
-	key := pbkdf(sha1Sum, 20, 64, macData.MacSalt, password, macData.Iterations, 3, 20)
-
-	mac := hmac.New(sha1.New, key)
-	mac.Write(message)
-	macData.Mac.Digest = mac.Sum(nil)
-
+	macData.Mac.Digest = digest
 	return nil
 }

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -580,17 +580,18 @@ func (enc *Encoder) Encode(privateKey interface{}, certificate *x509.Certificate
 	}
 
 	var certBags []safeBag
-	var certBag *safeBag
-	if certBag, err = makeCertBag(certificate.Raw, []pkcs12Attribute{localKeyIdAttr}); err != nil {
+	if certBag, err := makeCertBag(certificate.Raw, []pkcs12Attribute{localKeyIdAttr}); err != nil {
 		return nil, err
+	} else {
+		certBags = append(certBags, *certBag)
 	}
-	certBags = append(certBags, *certBag)
 
 	for _, cert := range caCerts {
-		if certBag, err = makeCertBag(cert.Raw, []pkcs12Attribute{}); err != nil {
+		if certBag, err := makeCertBag(cert.Raw, []pkcs12Attribute{}); err != nil {
 			return nil, err
+		} else {
+			certBags = append(certBags, *certBag)
 		}
-		certBags = append(certBags, *certBag)
 	}
 
 	var keyBag safeBag

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -865,18 +865,18 @@ func makeSafeContents(rand io.Reader, bags []safeBag, algoID asn1.ObjectIdentifi
 			return
 		}
 	} else {
+		randomSalt := make([]byte, saltLen)
+		if _, err = rand.Read(randomSalt); err != nil {
+			return
+		}
 
 		var algo pkix.AlgorithmIdentifier
 		algo.Algorithm = algoID
 		if algoID.Equal(oidPBES2) {
-			if algo.Parameters.FullBytes, err = makePBES2Parameters(rand, iterations, saltLen); err != nil {
+			if algo.Parameters.FullBytes, err = makePBES2Parameters(rand, randomSalt, iterations); err != nil {
 				return
 			}
 		} else {
-			randomSalt := make([]byte, saltLen)
-			if _, err = rand.Read(randomSalt); err != nil {
-				return
-			}
 			if algo.Parameters.FullBytes, err = asn1.Marshal(pbeParams{Salt: randomSalt, Iterations: iterations}); err != nil {
 				return
 			}

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -116,7 +116,7 @@ var LegacyDESCert = &Encoder{
 // Passwordless encodes PKCS#12 trust stores without any encryption,
 // for compatibility with the password-less keystores introduced in Java 18.
 //
-// When using this encoder, you must specify an empty password.
+// When using this encoder, you MUST specify an empty password.
 var Passwordless = &Encoder{
 	macAlgorithm:  nil,
 	certAlgorithm: nil,

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -55,9 +55,6 @@ type Encoder struct {
 // Due to the weak encryption, it is STRONGLY RECOMMENDED that you use [DefaultPassword]
 // when encoding PKCS#12 files using this encoder, and protect the PKCS#12 files
 // using other means.
-//
-// The behavior of this encoder is frozen and will not change in future
-// versions of this package.
 var Legacy = &Encoder{
 	macAlgorithm:         oidSHA1,
 	certAlgorithm:        oidPBEWithSHAAnd40BitRC2CBC,
@@ -72,9 +69,6 @@ var Legacy = &Encoder{
 // Due to the weak encryption, it is STRONGLY RECOMMENDED that you use [DefaultPassword]
 // when encoding PKCS#12 files using this encoder, and protect the PKCS#12 files
 // using other means.
-//
-// The behavior of this encoder is frozen and will not change in future
-// versions of this package.
 var LegacyDESCert = &Encoder{
 	macAlgorithm:         oidSHA1,
 	certAlgorithm:        oidPBEWithSHAAnd3KeyTripleDESCBC,
@@ -88,9 +82,6 @@ var LegacyDESCert = &Encoder{
 //
 // When using this encoder, you must specify an empty password.  Currently, you
 // can only use this encoder with EncodeTrustStore and EncodeTrustStoreEntries.
-//
-// The behavior of this encoder is frozen and will not change in future
-// versions of this package.
 var Passwordless = &Encoder{
 	macAlgorithm:  nil,
 	certAlgorithm: nil,
@@ -100,9 +91,6 @@ var Passwordless = &Encoder{
 // Openssl3 encodes PKCS#12 files using OpenSSL 3's default parameters.
 // Private keys and certificates are encrypted using PBES2 with PBKDF2
 // (2048 iterations of HMAC-SHA-2) and AES-256-CBC.  The MAC algorithm is HMAC-SHA-2.
-//
-// The behavior of this encoder is frozen and will not change in future
-// versions of this package.
 var Openssl3 = &Encoder{
 	macAlgorithm:         oidSHA256,
 	certAlgorithm:        oidPBES2,
@@ -115,8 +103,8 @@ var Openssl3 = &Encoder{
 // Private keys and certificates are encrypted using PBES2 with PBKDF2
 // (600,000 iterations of HMAC-SHA-2) and AES-256-CBC.  The MAC algorithm is HMAC-SHA-2.
 //
-// The behavior of this encoder will change in future versions of this
-// package to keep up with modern practices.
+// The behavior of this encoder may change in backwards-incompatible ways
+// to keep up with modern practices.
 var Modern = &Encoder{
 	macAlgorithm:         oidSHA256,
 	certAlgorithm:        oidPBES2,
@@ -409,6 +397,9 @@ func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certi
 // DecodeTrustStore extracts the certificates from pfxData, which must be a DER-encoded
 // PKCS#12 file containing exclusively certificates with attribute 2.16.840.1.113894.746875.1.1,
 // which is used by Java to designate a trust anchor.
+//
+// If the password argument is empty, DecodeTrustStore will decode either password-less
+// PKCS#12 files (i.e. those without encryption) or files with a literal empty password.
 func DecodeTrustStore(pfxData []byte, password string) (certs []*x509.Certificate, err error) {
 	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
@@ -528,7 +519,7 @@ func getSafeContents(p12Data, password []byte, expectedItems int) (bags []safeBa
 	return bags, password, nil
 }
 
-// Encode is equivalent to Legacy.Encode.
+// Encode is equivalent to Legacy.Encode.  See [Encoder.Encode] and [Legacy] for details.
 //
 // Deprecated: call Legacy.Encode to continue using legacy/weak encryption, or consider
 // one of the other encoders for better encryption.
@@ -642,7 +633,7 @@ func (enc *Encoder) Encode(rand io.Reader, privateKey interface{}, certificate *
 	return
 }
 
-// EncodeTrustStore is equivalent to Legacy.EncodeTrustStore.
+// EncodeTrustStore is equivalent to Legacy.EncodeTrustStore.  See [Encoder.EncodeTrustStore] and [Legacy] for details.
 //
 // Deprecated: call Legacy.EncodeTrustStore to continue using legacy encryption, or consider
 // one of the other encoders, such as [Passwordless].
@@ -683,6 +674,7 @@ type TrustStoreEntry struct {
 }
 
 // EncodeTrustStoreEntries is equivalent to Legacy.EncodeTrustStoreEntries.
+// See [Encoder.EncodeTrustStoreEntries] and [Legacy] for details.
 //
 // Deprecated: call Legacy.EncodeTrustStoreEntries to continue using legacy encryption, or consider
 // one of the other encoders, such as Passwordless.

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -48,6 +48,27 @@ type Encoder struct {
 	rand                 io.Reader
 }
 
+// WithIterations creates a new Encoder identical to enc except that
+// it will use the given number of KDF iterations for deriving the MAC
+// and encryption keys.
+//
+// Note that even with a large number of iterations, a weak
+// password can still be brute-forced in much less time than it would
+// take to brute-force a high-entropy encrytion key.  For the best
+// security, don't worry about the number of iterations and just
+// use a high-entropy password (e.g. one generated with `openssl rand -hex 16`).
+// See https://neilmadden.blog/2023/01/09/on-pbkdf2-iterations/ for more detail.
+//
+// Panics if iterations is less than 1.
+func (enc Encoder) WithIterations(iterations int) *Encoder {
+	if iterations < 1 {
+		panic("pkcs12: number of iterations is less than 1")
+	}
+	enc.macIterations = iterations
+	enc.encryptionIterations = iterations
+	return &enc
+}
+
 // WithRand creates a new Encoder identical to enc except that
 // it will use the given io.Reader for its random number generator
 // instead of [crypto/rand.Reader].

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -139,7 +139,7 @@ var Passwordless = &Encoder{
 //
 // You SHOULD NOT use a lower-entropy password with this encoder because the number of KDF
 // iterations is only 2048 and doesn't provide meaningful protection against
-// brute forcing.  You can increase the number of iterations using [Encoder.WithIterations],
+// brute-forcing.  You can increase the number of iterations using [Encoder.WithIterations],
 // but as https://neilmadden.blog/2023/01/09/on-pbkdf2-iterations/ explains, this doesn't
 // help as much as you think.
 var Modern2023 = &Encoder{

--- a/safebags.go
+++ b/safebags.go
@@ -47,23 +47,29 @@ func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{
 	return privateKey, nil
 }
 
-func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, password []byte) (asn1Data []byte, err error) {
+func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, algoID asn1.ObjectIdentifier, password []byte, iterations int) (asn1Data []byte, err error) {
 	var pkData []byte
 	if pkData, err = x509.MarshalPKCS8PrivateKey(privateKey); err != nil {
 		return nil, errors.New("pkcs12: error encoding PKCS#8 private key: " + err.Error())
 	}
 
-	randomSalt := make([]byte, 8)
-	if _, err = rand.Read(randomSalt); err != nil {
-		return nil, errors.New("pkcs12: error reading random salt: " + err.Error())
-	}
 	var paramBytes []byte
-	if paramBytes, err = asn1.Marshal(pbeParams{Salt: randomSalt, Iterations: 2048}); err != nil {
-		return nil, errors.New("pkcs12: error encoding params: " + err.Error())
+	if algoID.Equal(oidPBES2) {
+		if paramBytes, err = makePBES2Parameters(rand, iterations); err != nil {
+			return nil, errors.New("pkcs12: error encoding params: " + err.Error())
+		}
+	} else {
+		randomSalt := make([]byte, 8)
+		if _, err = rand.Read(randomSalt); err != nil {
+			return nil, errors.New("pkcs12: error reading random salt: " + err.Error())
+		}
+		if paramBytes, err = asn1.Marshal(pbeParams{Salt: randomSalt, Iterations: iterations}); err != nil {
+			return nil, errors.New("pkcs12: error encoding params: " + err.Error())
+		}
 	}
 
 	var pkinfo encryptedPrivateKeyInfo
-	pkinfo.AlgorithmIdentifier.Algorithm = oidPBEWithSHAAnd3KeyTripleDESCBC
+	pkinfo.AlgorithmIdentifier.Algorithm = algoID
 	pkinfo.AlgorithmIdentifier.Parameters.FullBytes = paramBytes
 
 	if err = pbEncrypt(&pkinfo, pkData, password); err != nil {

--- a/safebags.go
+++ b/safebags.go
@@ -48,7 +48,7 @@ func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{
 	return privateKey, nil
 }
 
-func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, algoID asn1.ObjectIdentifier, password []byte, iterations int) (asn1Data []byte, err error) {
+func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, algoID asn1.ObjectIdentifier, password []byte, iterations int, saltLen int) (asn1Data []byte, err error) {
 	var pkData []byte
 	if pkData, err = x509.MarshalPKCS8PrivateKey(privateKey); err != nil {
 		return nil, errors.New("pkcs12: error encoding PKCS#8 private key: " + err.Error())
@@ -56,11 +56,11 @@ func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, algoID as
 
 	var paramBytes []byte
 	if algoID.Equal(oidPBES2) {
-		if paramBytes, err = makePBES2Parameters(rand, iterations); err != nil {
+		if paramBytes, err = makePBES2Parameters(rand, iterations, saltLen); err != nil {
 			return nil, errors.New("pkcs12: error encoding params: " + err.Error())
 		}
 	} else {
-		randomSalt := make([]byte, 8)
+		randomSalt := make([]byte, saltLen)
 		if _, err = rand.Read(randomSalt); err != nil {
 			return nil, errors.New("pkcs12: error reading random salt: " + err.Error())
 		}

--- a/safebags.go
+++ b/safebags.go
@@ -15,6 +15,7 @@ import (
 var (
 	// see https://tools.ietf.org/html/rfc7292#appendix-D
 	oidCertTypeX509Certificate = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 9, 22, 1})
+	oidKeyBag                  = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 1})
 	oidPKCS8ShroundedKeyBag    = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 2})
 	oidCertBag                 = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 3})
 )

--- a/safebags.go
+++ b/safebags.go
@@ -54,16 +54,17 @@ func encodePkcs8ShroudedKeyBag(rand io.Reader, privateKey interface{}, algoID as
 		return nil, errors.New("pkcs12: error encoding PKCS#8 private key: " + err.Error())
 	}
 
+	randomSalt := make([]byte, saltLen)
+	if _, err = rand.Read(randomSalt); err != nil {
+		return nil, errors.New("pkcs12: error reading random salt: " + err.Error())
+	}
+
 	var paramBytes []byte
 	if algoID.Equal(oidPBES2) {
-		if paramBytes, err = makePBES2Parameters(rand, iterations, saltLen); err != nil {
+		if paramBytes, err = makePBES2Parameters(rand, randomSalt, iterations); err != nil {
 			return nil, errors.New("pkcs12: error encoding params: " + err.Error())
 		}
 	} else {
-		randomSalt := make([]byte, saltLen)
-		if _, err = rand.Read(randomSalt); err != nil {
-			return nil, errors.New("pkcs12: error reading random salt: " + err.Error())
-		}
 		if paramBytes, err = asn1.Marshal(pbeParams{Salt: randomSalt, Iterations: iterations}); err != nil {
 			return nil, errors.New("pkcs12: error encoding params: " + err.Error())
 		}


### PR DESCRIPTION
Instead of calling `pkcs12.Encode`, you now call the `Encode` method of an `Encoder` (likewise for `EncodeTrustStore` and `EncodeTrustStoreEntries`) which specifies what algorithms/parameters you want to use.

The following Encoders are available:

* `Legacy`, for the current behavior.

* `LegacyDESCerts`, to use 3DES for encrypting certificates (Closes #36, Closes #35).

* `Passwordless`, to create password-less trust stores like Java 18 (Closes #32).

* `Openssl3`, to match OpenSSL 3's modern algorithm choices (PBES2 with AES) (Closes #47).

* `Modern`, to always use the most modern choices (currently PBES2 with AES).

cc @Marc-Pons, @pivotal-david-osullivan, @Tookmund, @maraino, @hslatman