### PR TITLE
add support for decoding HMAC with SHA512 case

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -12,6 +12,7 @@ import (
 	"crypto/des"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
@@ -30,6 +31,7 @@ var (
 	oidPBKDF2                        = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 5, 12})
 	oidHmacWithSHA1                  = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 2, 7})
 	oidHmacWithSHA256                = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 2, 9})
+	oidHmacWithSHA512                = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 2, 11})
 	oidAES128CBC                     = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 1, 2})
 	oidAES192CBC                     = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 1, 22})
 	oidAES256CBC                     = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 1, 42})
@@ -222,6 +224,8 @@ func pbes2CipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher
 
 	var prf func() hash.Hash
 	switch {
+	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA512):
+		prf = sha512.New
 	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA256):
 		prf = sha256.New
 	case kdfParams.Prf.Algorithm.Equal(oidHmacWithSHA1):

--- a/mac.go
+++ b/mac.go
@@ -9,6 +9,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"hash"
@@ -29,6 +30,7 @@ type digestInfo struct {
 var (
 	oidSHA1   = asn1.ObjectIdentifier([]int{1, 3, 14, 3, 2, 26})
 	oidSHA256 = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 1})
+	oidSHA512 = asn1.ObjectIdentifier([]int{2, 16, 840, 1, 101, 3, 4, 2, 3})
 )
 
 func doMac(macData *macData, message, password []byte) ([]byte, error) {
@@ -41,6 +43,9 @@ func doMac(macData *macData, message, password []byte) ([]byte, error) {
 	case macData.Mac.Algorithm.Algorithm.Equal(oidSHA256):
 		hFn = sha256.New
 		key = pbkdf(sha256Sum, 32, 64, macData.MacSalt, password, macData.Iterations, 3, 32)
+	case macData.Mac.Algorithm.Algorithm.Equal(oidSHA512):
+		hFn = sha512.New
+		key = pbkdf(sha512Sum, 32, 64, macData.MacSalt, password, macData.Iterations, 3, 32)
 	default:
 		return nil, NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
 	}

--- a/pbkdf.go
+++ b/pbkdf.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"math/big"
 )
 
@@ -24,6 +25,12 @@ func sha1Sum(in []byte) []byte {
 // sha256Sum returns the SHA-256 hash of in.
 func sha256Sum(in []byte) []byte {
 	sum := sha256.Sum256(in)
+	return sum[:]
+}
+
+// sha512Sum returns the SHA-512 hash of in.
+func sha512Sum(in []byte) []byte {
+	sum := sha512.Sum512(in)
 	return sum[:]
 }
 


### PR DESCRIPTION
trying to address:

https://github.com/SSLMate/go-pkcs12/issues/59

for the the asn objectIdentifier  [here](https://github.com/SSLMate/go-pkcs12/pull/60/files#diff-69c5c48c1da9bf0e59ac32c7d0c0089fee30329073ffcc86cf7200f224f44ecfR34) i used this link: https://www.itu.int/ITU-T/formal-language/itu-t/x/x509/2019/AlgorithmObjectIdentifiers.html, under _id-hmacWithSHA512._ 

Note: kinda junior level in Go and def crypto...so would appreciate some help :-). 