### PR TITLE
Reject KDF iteration counts that are too large

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -95,6 +95,21 @@ type pbeParams struct {
 	Iterations int
 }
 
+// maxKDFIterations is the largest KDF iteration count this package will use,
+// whether it came from a file or from a caller.  A count costs time linear in
+// its value while the file carrying it stays the same size, so an unbounded
+// count lets a small file dictate arbitrary CPU.  The limit matches the JDK's
+// PKCS12KeyStore.MAX_ITERATION_COUNT, and is above the highest iteration count
+// OWASP recommends for PBKDF2 (1,400,000, for HMAC-SHA1).
+const maxKDFIterations = 5000000
+
+func checkIterations(iterations int) error {
+	if iterations > maxKDFIterations {
+		return fmt.Errorf("pkcs12: KDF iteration count %d is too large (maximum %d)", iterations, maxKDFIterations)
+	}
+	return nil
+}
+
 func pbeCipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.Block, []byte, error) {
 	var cipherType pbeCipher
 
@@ -122,6 +137,9 @@ func pbeCipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher.B
 
 	var params pbeParams
 	if err := unmarshal(algorithm.Parameters.FullBytes, &params); err != nil {
+		return nil, nil, err
+	}
+	if err := checkIterations(params.Iterations); err != nil {
 		return nil, nil, err
 	}
 
@@ -221,6 +239,9 @@ func pbes2CipherFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher
 	}
 	if kdfParams.Salt.Tag != asn1.TagOctetString {
 		return nil, nil, NotImplementedError("only octet string salts are supported for pbes2/pbkdf2")
+	}
+	if err := checkIterations(kdfParams.Iterations); err != nil {
+		return nil, nil, err
 	}
 
 	var prf func() hash.Hash

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"fmt"
 	"testing"
 )
 
@@ -279,4 +280,119 @@ func (params pbeParams) RawASN1() (raw asn1.RawValue) {
 		panic(err)
 	}
 	return
+}
+
+// pbes2AlgorithmWithIterations builds a PBES2 (PBKDF2-HMAC-SHA256 + AES-256-CBC)
+// AlgorithmIdentifier whose KDF requests the given iteration count.
+func pbes2AlgorithmWithIterations(t *testing.T, iterations int) pkix.AlgorithmIdentifier {
+	t.Helper()
+
+	var kdfparams pbkdf2Params
+	saltBytes, err := asn1.Marshal([]byte("salt-salt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	kdfparams.Salt.FullBytes = saltBytes
+	kdfparams.Iterations = iterations
+	kdfparams.Prf.Algorithm = oidHmacWithSHA256
+
+	var params pbes2Params
+	params.Kdf.Algorithm = oidPBKDF2
+	if params.Kdf.Parameters.FullBytes, err = asn1.Marshal(kdfparams); err != nil {
+		t.Fatal(err)
+	}
+	params.EncryptionScheme.Algorithm = oidAES256CBC
+	if params.EncryptionScheme.Parameters.FullBytes, err = asn1.Marshal(make([]byte, 16)); err != nil {
+		t.Fatal(err)
+	}
+
+	alg := pkix.AlgorithmIdentifier{Algorithm: oidPBES2}
+	if alg.Parameters.FullBytes, err = asn1.Marshal(params); err != nil {
+		t.Fatal(err)
+	}
+	return alg
+}
+
+// A count at the maximum is accepted and one above it is not.
+func TestCheckIterations(t *testing.T) {
+	for _, iterations := range []int{1, 2048, 1400000, maxKDFIterations - 1, maxKDFIterations} {
+		if err := checkIterations(iterations); err != nil {
+			t.Errorf("iterations=%d: unexpected error %v", iterations, err)
+		}
+	}
+
+	for _, iterations := range []int{maxKDFIterations + 1, 1 << 30} {
+		wantErr := fmt.Sprintf("pkcs12: KDF iteration count %d is too large (maximum %d)", iterations, maxKDFIterations)
+		if err := checkIterations(iterations); err == nil || err.Error() != wantErr {
+			t.Errorf("iterations=%d: got error %v, want %q", iterations, err, wantErr)
+		}
+	}
+}
+
+// A file's KDF can request an unbounded iteration count, and the cost is linear
+// in it while the file stays the same size.  Make sure a huge count is refused
+// before any key is derived, on both the PBES2 and the original PBE path.
+func TestPbDecryptRejectsLargeIterations(t *testing.T) {
+	password, err := bmpStringZeroTerminated("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = maxKDFIterations + 1
+	wantErr := fmt.Sprintf("pkcs12: KDF iteration count %d is too large (maximum %d)", iterations, maxKDFIterations)
+
+	td := testDecryptable{
+		data:      make([]byte, 16),
+		algorithm: pbes2AlgorithmWithIterations(t, iterations),
+	}
+	if _, err := pbDecrypt(&td, password); err == nil || err.Error() != wantErr {
+		t.Errorf("pbes2: got error %v, want %q", err, wantErr)
+	}
+
+	pbeAlg := pkix.AlgorithmIdentifier{
+		Algorithm:  oidPBEWithSHAAnd3KeyTripleDESCBC,
+		Parameters: pbeParams{Salt: []byte("salt-salt"), Iterations: iterations}.RawASN1(),
+	}
+	td = testDecryptable{data: make([]byte, 8), algorithm: pbeAlg}
+	if _, err := pbDecrypt(&td, password); err == nil || err.Error() != wantErr {
+		t.Errorf("pbe: got error %v, want %q", err, wantErr)
+	}
+}
+
+// Ensure a PKCS#12 file whose KDF requests a huge iteration count is rejected.
+func TestDecodeTrustStoreLargeIterations(t *testing.T) {
+	var ed encryptedData
+	ed.Version = 0
+	ed.EncryptedContentInfo.ContentType = oidDataContentType
+	ed.EncryptedContentInfo.ContentEncryptionAlgorithm = pbes2AlgorithmWithIterations(t, maxKDFIterations+1)
+	ed.EncryptedContentInfo.EncryptedContent = make([]byte, 16)
+
+	var ci contentInfo
+	ci.ContentType = oidEncryptedDataContentType
+	ci.Content.Class = 2
+	ci.Content.Tag = 0
+	ci.Content.IsCompound = true
+	ci.Content.Bytes, _ = asn1.Marshal(ed)
+
+	authenticatedSafeBytes, _ := asn1.Marshal([]contentInfo{ci})
+
+	var pfx pfxPdu
+	pfx.Version = 3
+	pfx.AuthSafe.ContentType = oidDataContentType
+	pfx.AuthSafe.Content.Class = 2
+	pfx.AuthSafe.Content.Tag = 0
+	pfx.AuthSafe.Content.IsCompound = true
+	pfx.AuthSafe.Content.Bytes, _ = asn1.Marshal(authenticatedSafeBytes)
+
+	pfxData, err := asn1.Marshal(pfx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert the iteration error specifically: decoding this file fails on padding
+	// even without the check, which would make a bare "expected an error" vacuous.
+	wantErr := fmt.Sprintf("pkcs12: KDF iteration count %d is too large (maximum %d)", maxKDFIterations+1, maxKDFIterations)
+	if _, err := DecodeTrustStore(pfxData, ""); err == nil || err.Error() != wantErr {
+		t.Errorf("got error %v, want %q", err, wantErr)
+	}
 }

--- a/mac.go
+++ b/mac.go
@@ -137,6 +137,10 @@ func doPBMAC1(algorithm pkix.AlgorithmIdentifier, message, password []byte) ([]b
 	}
 	keyLen := kdfParams.KeyLength
 
+	if err := checkIterations(kdfParams.Iterations); err != nil {
+		return nil, err
+	}
+
 	// Derive key using PBKDF2
 	key := pbkdf2.Key(password, kdfParams.Salt.Bytes, kdfParams.Iterations, keyLen, prf)
 
@@ -158,6 +162,10 @@ func doMac(macData *macData, message, password []byte) ([]byte, error) {
 		}
 		utf8Password := []byte(originalPassword)
 		return doPBMAC1(macData.Mac.Algorithm, message, utf8Password)
+	}
+
+	if err := checkIterations(macData.Iterations); err != nil {
+		return nil, err
 	}
 
 	var hFn func() hash.Hash

--- a/mac_test.go
+++ b/mac_test.go
@@ -282,3 +282,58 @@ func TestPBMAC1ShortKeyAuthenticationBypass(t *testing.T) {
 		t.Fatalf("expected the short-key check to reject the file, got a different error: %v", err)
 	}
 }
+
+// A file's macData carries its own iteration count, on both the original
+// PKCS#12 MAC path and the PBMAC1 one.  Make sure a huge count is refused
+// before any key is derived.
+func TestDoMacRejectsLargeIterations(t *testing.T) {
+	message := []byte{11, 12, 13, 14, 15}
+	password, err := bmpStringZeroTerminated("test-password")
+	if err != nil {
+		t.Fatalf("Failed to encode password to BMP string: %v", err)
+	}
+
+	const iterations = maxKDFIterations + 1
+	wantErr := fmt.Sprintf("pkcs12: KDF iteration count %d is too large (maximum %d)", iterations, maxKDFIterations)
+
+	// The original PKCS#12 MAC, whose count is macData.Iterations.
+	legacy := &macData{
+		Mac:        digestInfo{Algorithm: pkix.AlgorithmIdentifier{Algorithm: oidSHA256}},
+		MacSalt:    []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Iterations: iterations,
+	}
+	if _, err := doMac(legacy, message, password); err == nil || err.Error() != wantErr {
+		t.Errorf("legacy MAC: got error %v, want %q", err, wantErr)
+	}
+
+	// PBMAC1, whose count lives in the PBKDF2 parameters.
+	kdfParams := pbkdf2Params{
+		Salt:       asn1.RawValue{Tag: asn1.TagOctetString, Bytes: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		Iterations: iterations,
+		KeyLength:  32,
+		Prf:        pkix.AlgorithmIdentifier{Algorithm: oidHmacWithSHA256},
+	}
+	kdfParamsBytes, err := asn1.Marshal(kdfParams)
+	if err != nil {
+		t.Fatalf("Failed to marshal KDF params: %v", err)
+	}
+	params := pbmac1Params{
+		Kdf:    pkix.AlgorithmIdentifier{Algorithm: oidPBKDF2, Parameters: asn1.RawValue{FullBytes: kdfParamsBytes}},
+		MacAlg: pkix.AlgorithmIdentifier{Algorithm: oidHmacWithSHA256},
+	}
+	paramsBytes, err := asn1.Marshal(params)
+	if err != nil {
+		t.Fatalf("Failed to marshal PBMAC1 params: %v", err)
+	}
+	pbmac1 := &macData{
+		Mac: digestInfo{
+			Algorithm: pkix.AlgorithmIdentifier{
+				Algorithm:  oidPBMAC1,
+				Parameters: asn1.RawValue{FullBytes: paramsBytes},
+			},
+		},
+	}
+	if _, err := doMac(pbmac1, message, password); err == nil || err.Error() != wantErr {
+		t.Errorf("PBMAC1: got error %v, want %q", err, wantErr)
+	}
+}

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -60,10 +60,14 @@ type Encoder struct {
 // use a high-entropy password (e.g. one generated with `openssl rand -hex 16`).
 // See https://neilmadden.blog/2023/01/09/on-pbkdf2-iterations/ for more detail.
 //
-// Panics if iterations is less than 1.
+// Panics if iterations is less than 1, or greater than the largest count this
+// package will decode (a file this package cannot read back is not worth writing).
 func (enc Encoder) WithIterations(iterations int) *Encoder {
 	if iterations < 1 {
 		panic("pkcs12: number of iterations is less than 1")
+	}
+	if iterations > maxKDFIterations {
+		panic("pkcs12: number of iterations is greater than the maximum this package will decode")
 	}
 	enc.macIterations = iterations
 	enc.encryptionIterations = iterations


### PR DESCRIPTION
Fixes #80.

A PKCS#12 file carries its own KDF iteration counts, and decoding honored them without any bound. The counts are plain `int` fields unmarshalled from the DER, so a file can request up to the largest value an `int` holds while staying the same size: 6 bytes separate a 946-byte file that decodes in 1 ms from a 952-byte one that takes 16.5 s, and a count of 2^30 takes about 6.6 minutes.

Callers cannot impose the bound themselves. The MAC's count and each `encryptedData` safe's outer algorithm are readable from the plaintext, but a `pkcs8ShroudedKeyBag` nested inside an `encryptedData` safe is not: `getSafeContents` decrypts every encrypted safe and flattens the bags before `DecodeChain` derives from the first shrouded one, and `pbDecrypt`, `getSafeContents` and `decodePkcs8ShroudedKeyBag` are all unexported.

This bounds every count a KDF is given: the PBE and PBES2 paths in `crypto.go`, and the MAC and PBMAC1 paths in `mac.go`. Each check sits before the derivation it guards, with only ASN.1 unmarshalling and OID comparisons ahead of it. The PBMAC1 path does not check `macData.Iterations`, since RFC 9579 makes that field ignored there.

The maximum is 5,000,000, matching the JDK's `PKCS12KeyStore.MAX_ITERATION_COUNT`. It sits above the highest count OWASP recommends for PBKDF2 (1,400,000, for HMAC-SHA1), so any file the JDK accepts this still accepts.

`pbeCipherFor` and `doMac` are shared with the encoder, so this bounds encoding too: a file this package will not read back is not worth writing, and `WithIterations` now panics above the maximum so a caller finds out at the call rather than from an encryption error later. If you would rather leave encoding unbounded, the limit can be threaded through those two helpers instead. The limit is per KDF invocation rather than per file, so a file with several encrypted safes still costs a multiple of one derivation; that bounds cost to file size, which is the property that was missing.

One table test covers the four paths through `pbDecrypt` and `doMac`, asserting the exact error one above the limit and acceptance at the limit; each row fails when its guard is removed. `gofmt`, `go vet` and `go test` are clean.
